### PR TITLE
feat(xor): adds special support for xor errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,12 @@ exports.register = function (server, options, next) {
       msg = options.serverErrorMessage;
     } else if (err.data && err.data.details && err.data.details.length >= 1) {
       msg = err.data.details.map((detail) => {
-        if (detail.message.match(QUOTED_REGEX)) {
+        const path = detail.path === 'value' ? '' : `${detail.path}.`;
+        if (detail.type === 'object.missing') {
+          return `${path}${detail.context.peers[0]} or ${path}${detail.context.peers[1]} is required`;
+        } else if (detail.type === 'object.xor') {
+          return `either ${path}${detail.context.peers[0]} or ${path}${detail.context.peers[1]} is required, but not both`;
+        } else if (detail.message.match(QUOTED_REGEX)) {
           return detail.path + detail.message.replace(QUOTED_REGEX, '');
         }
         return detail.message;


### PR DESCRIPTION
This should help us fix some issues with XOR error messages that we are overriding with the `language` feature. This breaks down with nested XOR's because the top level `language` setting masks the nested ones.